### PR TITLE
meson: disable introspection if g-ir-scanner is not found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -220,6 +220,8 @@ if ignored_iface_prefix != ''
   cdata.set_quoted('IGNORED_IFACE_PREFIX', ignored_iface_prefix)
 endif
 
+gir = find_program('g-ir-scanner', required : get_option('introspection'))
+
 subdir('agent')
 subdir('stun')
 subdir('socket')

--- a/nice/meson.build
+++ b/nice/meson.build
@@ -32,7 +32,7 @@ install_headers('nice.h', subdir: 'nice')
 nice_include = include_directories('.')
 
 # introspection
-build_gir = not get_option('introspection').disabled() and get_option('default_library') != 'static'
+build_gir = gir.found() and not get_option('introspection').disabled() and get_option('default_library') != 'static'
 if build_gir
   nice_gen_sources += [
     gnome.generate_gir(libnice,


### PR DESCRIPTION
disable introspection if g-ir-scanner is not found